### PR TITLE
Add Open VSX publishing for Cursor and other editors

### DIFF
--- a/.github/workflows/publish-open-vsx.yml
+++ b/.github/workflows/publish-open-vsx.yml
@@ -1,0 +1,37 @@
+# This workflow publishes the extension to Open VSX Registry (used by Cursor and other editors)
+# For more information see: https://open-vsx.org/
+
+name: publish-open-vsx
+
+on:
+  workflow_call:
+
+jobs:
+  publish-open-vsx:
+    name: publish-open-vsx
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: 'recursive' # If you have submodules, set this to true
+      - name: Install Nodejs
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22.x
+      - name: Download artifact
+        id: download-artifact
+        uses: dawidd6/action-download-artifact@v7
+        with:
+          workflow: build_workflow.yml
+          name: package
+          path: ./editor/dist
+
+      - name: Publish Extension (Open VSX Registry, release)
+        working-directory: editor
+        run: |
+          npm i
+          npm install --global @vscode/vsce
+          npm install --global ovsx
+          # Publish to Open VSX Registry
+          ovsx publish ./dist/*.vsix --pat ${{ secrets.OPEN_VSX_TOKEN }}

--- a/.github/workflows/publish_workflow.yml
+++ b/.github/workflows/publish_workflow.yml
@@ -12,3 +12,7 @@ jobs:
     needs: call-build
     uses: ./.github/workflows/publish.yml
     secrets: inherit
+  call-publish-open-vsx:
+    needs: call-build
+    uses: ./.github/workflows/publish-open-vsx.yml
+    secrets: inherit


### PR DESCRIPTION
This PR adds support for publishing the extension to the Open VSX Registry, which is used by Cursor and other editors that support VS Code extensions.

## Changes

- Added a new workflow file `.github/workflows/publish-open-vsx.yml` that publishes to Open VSX using the `ovsx` CLI tool
- Updated `.github/workflows/publish_workflow.yml` to include the Open VSX publishing step alongside the existing VS Code Marketplace publishing

## Setup Required

To enable publishing, the repository maintainers will need to:

1. Create an account on [Open VSX](https://open-vsx.org/)
2. Generate a Personal Access Token from the account settings
3. Add the token as a GitHub secret named `OPEN_VSX_TOKEN` in the repository settings

Once the secret is configured, the workflow will automatically publish new releases to Open VSX whenever changes are pushed to the main branch.

## Benefits

- Makes the extension available to Cursor users